### PR TITLE
fix uv add error and last_trade_price error

### DIFF
--- a/polypy/structs.py
+++ b/polypy/structs.py
@@ -253,17 +253,6 @@ class BookEvent(
         return "book"
 
 
-class LastTradePricePayload(msgspec.Struct, forbid_unknown_fields=True):
-    asset_id: str
-    fee_rate_bps: str
-    price: str
-    side: SIDE
-    size: str
-    timestamp: int
-    market: str | None = None
-    transaction_hash: str | None = None
-
-
 class PriceChangeEvent(
     msgspec.Struct,
     forbid_unknown_fields=True,
@@ -273,7 +262,7 @@ class PriceChangeEvent(
     market: str
     price_changes: list[PriceChangeSummary]
     timestamp: int
-    last_trade_price: LastTradePricePayload | None = None
+    last_trade_price: str | None = None
 
     @property
     def event_type(self) -> str:

--- a/polypy/structs.py
+++ b/polypy/structs.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Literal, Union
+from typing import Literal, Union
 
 import msgspec
 
@@ -262,7 +262,6 @@ class PriceChangeEvent(
     market: str
     price_changes: list[PriceChangeSummary]
     timestamp: int
-    last_trade_price: str | None = None
 
     @property
     def event_type(self) -> str:
@@ -299,8 +298,7 @@ class LastTradePriceEvent(
     side: SIDE
     size: str
     timestamp: int
-    transaction_hash: str | None = None
-    last_trade_price: dict[str, Any] | None = None
+    transaction_hash: str
 
     @property
     def event_type(self) -> str:

--- a/polypy/structs.py
+++ b/polypy/structs.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Literal, Union
+from typing import Any, Literal, Union
 
 import msgspec
 
@@ -246,10 +246,22 @@ class BookEvent(
     hash: str
     bids: list[OrderSummary]
     asks: list[OrderSummary]
+    last_trade_price: str | None = None
 
     @property
     def event_type(self) -> str:
         return "book"
+
+
+class LastTradePricePayload(msgspec.Struct, forbid_unknown_fields=True):
+    asset_id: str
+    fee_rate_bps: str
+    price: str
+    side: SIDE
+    size: str
+    timestamp: int
+    market: str | None = None
+    transaction_hash: str | None = None
 
 
 class PriceChangeEvent(
@@ -261,6 +273,7 @@ class PriceChangeEvent(
     market: str
     price_changes: list[PriceChangeSummary]
     timestamp: int
+    last_trade_price: LastTradePricePayload | None = None
 
     @property
     def event_type(self) -> str:
@@ -297,6 +310,8 @@ class LastTradePriceEvent(
     side: SIDE
     size: str
     timestamp: int
+    transaction_hash: str | None = None
+    last_trade_price: dict[str, Any] | None = None
 
     @property
     def event_type(self) -> str:

--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,14 @@ def read_requirements(filename: str):
         return [
             r
             for r in reqs
-            if not re.match(r".*\.txt.*requirements.*", r, re.IGNORECASE)
+            if not r.startswith("-")
         ]
 
 
 setup(
     name="polypy",
     version="0.0.0",
-    install_requirements=read_requirements("requirements.txt"),
+    install_requires=read_requirements("requirements.txt"),
     extras_require={
         "dev": read_requirements("requirements-dev.txt"),
         "examples": read_requirements("requirements-examples.txt"),


### PR DESCRIPTION
fix error while using uv add

```
(base) (polymarket) PS D:\Programing\polymarket> uv add https://github.com/hbr-l/polypy.git
 Updated https://github.com/hbr-l/polypy.git (bd9a728)
error: The build backend returned an error                                                                                             
  Caused by: Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit code: 1)

[stderr]
C:\Users\Doiiars\AppData\Local\uv\cache\builds-v0\.tmpMNIZJg\Lib\site-packages\setuptools\_distutils\dist.py:289: UserWarning: Unknown distribution option: 'install_requirements'
  warnings.warn(msg)
error in polypy setup command: 'extras_require' must be a dictionary whose values are strings or lists of strings containing valid project/version requirement specifiers.

hint: This usually indicates a problem with the package or the build environment.
```

fix error https://github.com/hbr-l/polypy/issues/5